### PR TITLE
Fix timestamp

### DIFF
--- a/python/vimsence.py
+++ b/python/vimsence.py
@@ -3,7 +3,7 @@ import rpc
 import time
 import logging
 
-start_time = time.time()
+start_time = int(time.time())
 base_activity = {
         'details': 'Nothing',
         'timestamps': {


### PR DESCRIPTION
The start timestamp requires an integer. Since time.time() will return a float, this will get incorrectly parsed resulting in Discord showing a playtime of 14-16 hours right off the bat.